### PR TITLE
Makefile.am: fix build with latest automake

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,6 +32,6 @@ pam_nfc_add_SOURCES = \
         pam-nfc-add.c
     
 pam_nfc_add_LDADD = \
-	-lnfcauth
+	libnfcauth.la
 
 EXTRA_DIST = nfcauth.h


### PR DESCRIPTION
Fix the following build failure with latest automake (at least version 1.16.4):

```
make[1]: Entering directory '/home/giuliobenetti/autobuild/run/instance-2/output-1/build/libpam-nfc-bb762e0e649195110e015ffb605c4375e927c437'
  CC       pam-nfc-add.o
  CCLD     pam-nfc-add
/home/giuliobenetti/autobuild/run/instance-2/output-1/host/opt/ext-toolchain/bin/../lib/gcc/i686-buildroot-linux-uclibc/9.3.0/../../../../i686-buildroot-linux-uclibc/bin/ld: cannot find -lnfcauth
```

Fixes:
 - http://autobuild.buildroot.org/results/4f6018cb44770ea8fb9a9eb24c161239c2d04c27

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>